### PR TITLE
Handle find xml repeated object

### DIFF
--- a/internal/xmlutil/xml.go
+++ b/internal/xmlutil/xml.go
@@ -113,6 +113,7 @@ func ValidateFormatting(raw []byte) error {
 func IsStartElement(line []byte) (*xml.StartElement, bool) {
 	d := xml.NewDecoder(bytes.NewReader(bytes.TrimSpace(line)))
 
+	// TODO: Use xml.Decoder.Token() instead of RawToken().
 	t, err := d.RawToken()
 	if err != nil {
 		return &xml.StartElement{}, false
@@ -249,6 +250,7 @@ func lineIndentInfo(line []byte) (indentChar rune, count int) {
 func IsEndElement(line []byte) (*xml.EndElement, bool) {
 	d := xml.NewDecoder(bytes.NewReader(bytes.TrimSpace(line)))
 
+	// TODO: Use xml.Decoder.Token() instead of RawToken().
 	t, err := d.RawToken()
 	if err != nil {
 		return &xml.EndElement{}, false

--- a/internal/xmlutil/xml.go
+++ b/internal/xmlutil/xml.go
@@ -195,6 +195,9 @@ func FindObject(config FindObjectConfig) (RawObject, error) {
 			rawObject.bodyIndentCount = count
 		}
 
+		// TODO: Need to verify that the tokens match using
+		//  URL / namespace in addition to the token name.
+		//  This will require a fair amount of reworking.
 		if start, isStart := IsStartElement(line); isStart {
 			if start.Name.Local == config.Start().Name.Local {
 				requireEndCount = requireEndCount + 1

--- a/internal/xmlutil/xml.go
+++ b/internal/xmlutil/xml.go
@@ -195,17 +195,17 @@ func FindObject(config FindObjectConfig) (RawObject, error) {
 			rawObject.bodyIndentCount = count
 		}
 
-		start, isStart := IsStartElement(line)
-		if isStart && start.Name.Local == config.Start().Name.Local {
-			requireEndCount = requireEndCount + 1
-		}
-
-		end, isEnd := IsEndElement(line)
-		if isEnd && end.Name.Local == config.Start().Name.Local {
-			if requireEndCount <= 1 {
-				break
-			} else {
-				requireEndCount = requireEndCount - 1
+		if start, isStart := IsStartElement(line); isStart {
+			if start.Name.Local == config.Start().Name.Local {
+				requireEndCount = requireEndCount + 1
+			}
+		} else if end, isEnd := IsEndElement(line); isEnd {
+			if end.Name.Local == config.Start().Name.Local {
+				if requireEndCount <= 1 {
+					break
+				} else {
+					requireEndCount = requireEndCount - 1
+				}
 			}
 		}
 

--- a/internal/xmlutil/xml_test.go
+++ b/internal/xmlutil/xml_test.go
@@ -1,0 +1,168 @@
+package xmlutil
+
+import (
+	"bufio"
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type testVhs struct {
+	XMLName xml.Name  `xml:"VirtualHardwareSection"`
+	Info   string     `xml:"Info"`
+	System testSystem
+}
+
+type testSystem struct {
+	XMLName xml.Name `xml:"System"`
+	ElementName             string
+	InstanceId              string
+	VirtualSystemIdentifier string
+	VirtualSystemType       string
+}
+
+var (
+	testEol = []byte{'\n'}
+)
+
+func TestFindObject(t *testing.T) {
+	junk := `<VirtualHardwareSection>
+    <Info>Virtual hardware requirements for a virtual machine</Info>
+    <System>
+        <ElementName>Virtual Hardware Family</ElementName>
+        <InstanceID>0</InstanceID>
+        <VirtualSystemIdentifier>centos7</VirtualSystemIdentifier>
+        <VirtualSystemType>junk</VirtualSystemType>
+    </System>
+</VirtualHardwareSection>
+`
+
+	scanner := bufio.NewScanner(strings.NewReader(junk))
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		start, isStart := IsStartElement(line)
+		if isStart && start.Name.Local == "System" {
+			config, err := NewFindObjectConfig(start, scanner, testEol)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			rawObject, err := FindObject(config)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			expected := `    <System>
+        <ElementName>Virtual Hardware Family</ElementName>
+        <InstanceID>0</InstanceID>
+        <VirtualSystemIdentifier>centos7</VirtualSystemIdentifier>
+        <VirtualSystemType>junk</VirtualSystemType>
+    </System>`
+
+			if rawObject.StartAndEndLinePrefix() != "    " {
+				t.Fatal("Got unexpected start/end prefix of '" + rawObject.RelativeBodyPrefix() + "'")
+			}
+
+			if rawObject.BodyPrefix() != "        " {
+				t.Fatal("Got unexpected body prefix of '" + rawObject.BodyPrefix() + "'")
+			}
+
+			if rawObject.RelativeBodyPrefix() != "    " {
+				t.Fatal("Got unexpected relative body prefix of '" + rawObject.RelativeBodyPrefix() + "'")
+			}
+
+			if rawObject.Data().String() == expected {
+				return
+			} else {
+      			t.Fatal("Got unexpected result: \n'" + rawObject.Data().String() + "'")
+			}
+		}
+	}
+
+	err := scanner.Err()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	t.Fatal("Could not find target object")
+}
+
+func TestFindObjectEmbeddedObject(t *testing.T) {
+	junk := `<VirtualHardwareSection>
+    <Info>Virtual hardware requirements for a virtual machine</Info>
+    <System>
+        <ElementName>Virtual Hardware Family</ElementName>
+        <InstanceID>0</InstanceID>
+        <VirtualSystemIdentifier>centos7</VirtualSystemIdentifier>
+        <VirtualSystemType>junk</VirtualSystemType>
+        <System>
+            <ElementName>Virtual Hardware Family</ElementName>
+            <InstanceID>0</InstanceID>
+            <VirtualSystemIdentifier>centos7</VirtualSystemIdentifier>
+            <VirtualSystemType>junk</VirtualSystemType>
+        </System>
+    </System>
+</VirtualHardwareSection>
+`
+
+	scanner := bufio.NewScanner(strings.NewReader(junk))
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		start, isStart := IsStartElement(line)
+		if isStart && start.Name.Local == "System" {
+			config, err := NewFindObjectConfig(start, scanner, testEol)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			rawObject, err := FindObject(config)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			expected := `    <System>
+        <ElementName>Virtual Hardware Family</ElementName>
+        <InstanceID>0</InstanceID>
+        <VirtualSystemIdentifier>centos7</VirtualSystemIdentifier>
+        <VirtualSystemType>junk</VirtualSystemType>
+        <System>
+            <ElementName>Virtual Hardware Family</ElementName>
+            <InstanceID>0</InstanceID>
+            <VirtualSystemIdentifier>centos7</VirtualSystemIdentifier>
+            <VirtualSystemType>junk</VirtualSystemType>
+        </System>
+    </System>`
+
+			if rawObject.StartAndEndLinePrefix() != "    " {
+				t.Fatal("Got unexpected start/end prefix of '" + rawObject.RelativeBodyPrefix() + "'")
+			}
+
+			if rawObject.BodyPrefix() != "        " {
+				t.Fatal("Got unexpected body prefix of '" + rawObject.BodyPrefix() + "'")
+			}
+
+			if rawObject.RelativeBodyPrefix() != "    " {
+				t.Fatal("Got unexpected relative body prefix of '" + rawObject.RelativeBodyPrefix() + "'")
+			}
+
+			if rawObject.Data().String() == expected {
+				fmt.Println(rawObject.Data().String())
+				return
+			} else {
+				t.Fatal("Got unexpected result: \n'" + rawObject.Data().String() + "'")
+			}
+		}
+	}
+
+	err := scanner.Err()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	t.Fatal("Could not find target object")
+}


### PR DESCRIPTION
This handles situations where the same XML object is embedded
inside of itself.

There are still edge cases that need to be handled, such as verifying
each XML token's namespace / URL.